### PR TITLE
Enable full access on identity.deso.org

### DIFF
--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -2,7 +2,7 @@ export const environment = {
   production: true,
   hostname: 'identity.deso.org',
   nodeHostname: 'bitclout.com',
-  fullAccessHostnames: ['bitclout.com', 'bitclout.green', 'bitclout.blue', 'localhost', 'buy.deso.org'],
+  fullAccessHostnames: ['bitclout.com', 'bitclout.green', 'bitclout.blue', 'localhost', 'buy.deso.org', 'identity.deso.org'],
   noAccessHostnames: [''],
   jumioSupported: false,
 };


### PR DESCRIPTION
Right now its not possible for identity on deso to get full access permissions.

I think this PR fixes that.