### PR TITLE
Phone verification mobile cb

### DIFF
--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -77,7 +77,18 @@ export class IdentityService {
     jumioSuccess?: boolean,
     phoneNumberSuccess?: boolean,
   }): void {
-    this.cast('login', payload);
+    if (this.globalVars.callback) {
+      // If callback is passed, we redirect to it with payload as URL parameters.
+      let httpParams = new HttpParams();
+      for (const key in payload) {
+        if (payload.hasOwnProperty(key)) {
+          httpParams = httpParams.append(key, (payload as any)[key].toString());
+        }
+      }
+      window.location.href = this.globalVars.callback + `?${httpParams.toString()}`;
+    } else {
+      this.cast('login', payload);
+    }
   }
 
   derive(payload: {

--- a/src/app/sign-up-get-starter-deso/sign-up-get-starter-deso.component.html
+++ b/src/app/sign-up-get-starter-deso/sign-up-get-starter-deso.component.html
@@ -5,7 +5,8 @@
       (click)="finishFlow()"
       class="button button-secondary button-large font-weight-bold fs-15px sign-up-btn"
     >
-      Continue to {{ globalVars.hostname }}
+      <div *ngIf="globalVars.callback; else elseBlock">Continue</div>
+      <ng-template #elseBlock>Continue to {{ globalVars.hostname }}</ng-template>
     </button>
   </div>
 </ng-template>


### PR DESCRIPTION
Since we can't use web view on mobile to sign in users on mobile, we are using Chrome Custom Tabs for Android & SafariServices/AuthenticationServices for iOS. Given the security restrictions for those, we can't use postMessage to communicate with the identity service. 

In this PR I'm adding the possibility to call a callback instead of postMessage in case it's provided in the URL. 
Also, I'm changing ( if callback is provided ) the "Continue to localhost" message at the end of the phone verification process to just "Continue" so it's less confusing for the user.
