### PR TITLE
Signing arbitrary messages

### DIFF
--- a/src/app/approve/approve.component.html
+++ b/src/app/approve/approve.component.html
@@ -2,7 +2,7 @@
 
 <div class="page-container">
   <div class="title-text">
-    Approve a transaction
+    {{ messageHex ? "Sign a message" : "Approve a transaction" }}
   </div>
   <div class="main-text">
     <p class="pb-15px">
@@ -14,9 +14,16 @@
         Total Cost: {{ transactionDeSoSpent }} $DESO
       </p>
     </div>
+    <div *ngIf="messageHex" class="text-input-container">
+      <textarea class="text-input" [value]="getMessageAsText()" readonly></textarea>
+    </div>
     <div class="d-flex align-items-end justify-content-between">
-      <button type="button" class="button button-small button-secondary" (click)="onCancel()">Deny</button>
-      <button type="button" class="button button-small button-primary" (click)="onSubmit()">Allow</button>
+      <button type="button" class="button button-small button-secondary" (click)="onCancel()">
+        {{ messageHex ? "Cancel" : "Deny" }}
+      </button>
+      <button type="button" class="button button-small button-primary" (click)="onSubmit()">
+        {{ messageHex ? "Sign" : "Allow" }}
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -62,6 +62,10 @@ export class ApproveComponent implements OnInit {
 
   ngOnInit(): void {
     this.activatedRoute.queryParams.subscribe(params => {
+      if (params.tx && params.messageHex) {
+        console.error('Found transactionHex and messageHex in query parameters. Only messageHex will be used.');
+      }
+
       if (params.messageHex) {
         this.messageHex = params.messageHex;
         this.publicKey = params.publicKey;

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -32,6 +32,8 @@ export class GlobalVarsService {
 
   defaultMessageKeyName: string = 'default-key';
 
+  signPrefix: string = 'DeSo Signed Message:\n';
+
   constructor() { }
 
   isFullAccessHostname(): boolean {

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -146,25 +146,23 @@ export class IdentityService {
   private handleSign(data: any): void {
     const { id, payload: { encryptedSeedHex, transactionHex, messageHex } } = data;
 
-    const seedHex = this.cryptoService.decryptSeedHex(encryptedSeedHex, this.globalVars.hostname);
-
     if (transactionHex && messageHex) {
       console.error('Found transactionHex and messageHex in payload. Only messageHex will be used.');
     }
 
     if (messageHex) {
       // No transaction or spending here, so we just check if approval is required.
-      if (!this.hasAccessLevel(data, AccessLevel.ApproveLarge)) {
-        this.respond(data.id, {approvalRequired: true});
+      if (!this.approve(data, AccessLevel.ApproveLarge)) {
         return;
       }
 
+      const seedHex = this.cryptoService.decryptSeedHex(encryptedSeedHex, this.globalVars.hostname);
       const signedMessageHex = this.signingService.sign(seedHex, messageHex);
 
       this.respond(id, {
         signedMessageHex,
       });
-    } else if (transactionHex) {
+    } else {
       // This will tell us whether we need full signing access or just ApproveLarge
       // level of access.
       const requiredAccessLevel = this.getRequiredAccessLevel(transactionHex);
@@ -185,6 +183,7 @@ export class IdentityService {
         return;
       }
 
+      const seedHex = this.cryptoService.decryptSeedHex(encryptedSeedHex, this.globalVars.hostname);
       const signedTransactionHex = this.signingService.signTransaction(seedHex, transactionHex);
 
       this.respond(id, {

--- a/src/app/signing.service.ts
+++ b/src/app/signing.service.ts
@@ -167,8 +167,7 @@ export class SigningService {
     const contentLength = uvarint64ToBuf(contentBytes.length);
 
     // We add a prefix to prevent the caller from signing a transaction
-    const prefix = 'DeSo Signed Message:\n';
-    const prefixBytes = new Buffer(prefix, 'hex');
+    const prefixBytes = new Buffer(this.globalVars.signPrefix, 'utf-8');
 
     const messageBytes = Buffer.concat([
       prefixBytes,

--- a/src/lib/bindata/util.ts
+++ b/src/lib/bindata/util.ts
@@ -1,6 +1,6 @@
 export const bufToUvarint64 = (buffer: Buffer): [number, Buffer] => {
-  let x = 0;
-  let s = 0;
+  let x = BigInt(0);
+  let s = BigInt(0);
 
   for (let i = 0; true; i++) {
       const byte = buffer[i];
@@ -11,8 +11,8 @@ export const bufToUvarint64 = (buffer: Buffer): [number, Buffer] => {
         return [Number(BigInt(x) | BigInt(byte) << BigInt(s)), buffer.slice(i + 1)];
       }
 
-      x |= (byte & 0x7F) << s;
-      s += 7;
+      x |= BigInt((byte & 0x7F)) << BigInt(s);
+      s += BigInt(7);
   }
 };
 


### PR DESCRIPTION
Adds the ability to sign arbitrary plain text messages with Identity.

These changes include updating the `sign` iframe endpoint to support a `messageHex` parameter, and the Approve component to support signing messages.

MetaMask's [personal_sign](https://github.com/ethereum/go-ethereum/pull/2940) method was referenced when determining the structure for the signed message response.

`sign` returns an ECDSA signature for sha256.x2(message). A prefix is added to the message before hashing to prevent unwanted signing of a transaction. The hash is calculated with:

```
sha256.x2("DeSo Signed Message:\n"${message.length}${message})
```

A `signedMessageHex` is returned as part of the message payload when successful.

Here is the relevant snippet:

```ts
sign(seedHex: string, messageHex: string): string {
  const privateKey = this.cryptoService.seedHexToPrivateKey(seedHex);

  const contentBytes = new Buffer(messageHex, 'hex');
  const contentLength = uvarint64ToBuf(contentBytes.length);

  // We add a prefix to prevent the caller from signing a transaction
  const prefixBytes = new Buffer(this.globalVars.signPrefix, 'utf-8');

  const messageBytes = Buffer.concat([
    prefixBytes,
    contentLength,
    contentBytes,
  ]);
  const messageBytesLength = uvarint64ToBuf(messageBytes.length);
  const messageHash = new Buffer(sha256.x2(messageBytes), 'hex');

  const signature = privateKey.sign(messageHash);
  const signatureBytes = new Buffer(signature.toDER());
  const signatureLength = uvarint64ToBuf(signatureBytes.length);

  const signedMessageBytes = Buffer.concat([
    messageBytesLength,
    messageBytes,
    signatureLength,
    signatureBytes
  ])

  return signedMessageBytes.toString('hex');
}
```

An example of an iframe message:

```js
const payload = {
  accessLevel: user.accessLevel,
  accessLevelHmac: user.accessLevelHmac,
  encryptedSeedHex: user.encryptedSeedHex,
  messageHex: Buffer.from(text, 'hex')
}

const msg = {
  id: id,
  service: 'identity',
  method: 'sign',
  payload: payload
}

iframe.contentWindow.postMessage(msg, "*")
```

And the approval window URL construction, which requires that you also pass the `PublicKeyBase58Check` as `publicKey`:

```js
const url = new URL('https://identity.deso.org/approve')
const messageHex = Buffer.from(text, 'hex')
url.searchParams.set('messageHex', messageHex)
url.searchParams.set('publicKey', publicKey)
```

Here's a basic example of signature verification:

```js
const EC = require('elliptic').ec
const bs58check = require('bs58check')
const sha256 = require('sha256')

const verifySignedMessage = (publicKeyBase58Check, signedMessageHex) => {
  const signedMessageBytes = Buffer.from(signedMessageHex, 'hex')

  const messageBytesLength = signedMessageBytes[0]
  const messageBytes = signedMessageBytes.slice(1, messageBytesLength + 1)

  const messageHash = Buffer.from(sha256.x2(messageBytes), 'hex')
  const signature = signedMessageBytes.slice(messageBytesLength + 2).toString('hex')

  const decoded = bs58check.decode(publicKeyBase58Check)
  const publicKey = Uint8Array.from(decoded).slice(3)
  const ec = new EC('secp256k1')
  const publicKeyEC = ec.keyFromPublic(publicKey, 'array')

  return publicKeyEC.verify(messageHash, signature)
}
```

I will submit a PR to update the docs after this is merged. I also plan to add a Util class to [deso.js](https://github.com/bitclouthunt/deso.js/) with some functions to support this flow.