### PR TITLE
Set canonical option to true when signing transactions

### DIFF
--- a/src/app/signing.service.ts
+++ b/src/app/signing.service.ts
@@ -145,7 +145,7 @@ export class SigningService {
 
     const transactionBytes = new Buffer(transactionHex, 'hex');
     const transactionHash = new Buffer(sha256.x2(transactionBytes), 'hex');
-    const signature = privateKey.sign(transactionHash);
+    const signature = privateKey.sign(transactionHash, { canonical: true });
     const signatureBytes = new Buffer(signature.toDER());
     const signatureLength = uvarint64ToBuf(signatureBytes.length);
 


### PR DESCRIPTION
When the option `canonical` is set to `true`, the sign function will find the complement of a signature's S if S is greater than  half s256's N value.

@diamondhands0 - should we also apply this to the `signHashes` function?

https://github.com/indutny/elliptic/blob/master/lib/elliptic/ec/index.js#L147

