### PR TITLE
Skip HTTP param if undefined or null

### DIFF
--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -107,7 +107,7 @@ export class IdentityService {
         // If callback is passed, we redirect to it with payload as URL parameters.
         let httpParams = new HttpParams();
         for (const key in derivedPrivateUserInfo) {
-          if (derivedPrivateUserInfo.hasOwnProperty(key)) {
+          if (derivedPrivateUserInfo.hasOwnProperty(key) && (derivedPrivateUserInfo as any)[key]) {
             httpParams = httpParams.append(key, (derivedPrivateUserInfo as any)[key].toString());
           }
         }

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -107,8 +107,11 @@ export class IdentityService {
         // If callback is passed, we redirect to it with payload as URL parameters.
         let httpParams = new HttpParams();
         for (const key in derivedPrivateUserInfo) {
-          if (derivedPrivateUserInfo.hasOwnProperty(key) && (derivedPrivateUserInfo as any)[key]) {
-            httpParams = httpParams.append(key, (derivedPrivateUserInfo as any)[key].toString());
+          if (derivedPrivateUserInfo.hasOwnProperty(key)) {
+            const paramVal = (derivedPrivateUserInfo as any)[key];
+            if (paramVal !== null && paramVal !== undefined) {
+              httpParams = httpParams.append(key, paramVal.toString());
+            }
           }
         }
         window.location.href = this.globalVars.callback + `?${httpParams.toString()}`;


### PR DESCRIPTION
If a `transactionSpendingLimit` is not specified and a `callback` query param has been set, we will hit an error when trying to call `toString` on undefined. This update SKIPS query params if they are undefined or null.