### PR TITLE
Support DAO coin limit orders in identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "~11.1.1",
+    "@angular/cdk": "^11.1.1",
     "@angular/common": "~11.1.1",
     "@angular/compiler": "~11.1.1",
     "@angular/core": "~11.1.1",
@@ -28,6 +29,7 @@
     "bip39": "^3.0.3",
     "crypto-browserify": "^3.12.0",
     "elliptic": "^6.5.4",
+    "google-libphonenumber": "^3.2.27",
     "hdkey": "github:deso-protocol/hdkey",
     "intl-tel-input": "^17.0.3",
     "jsonwebtoken": "^8.5.1",

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -282,7 +282,9 @@ export class ApproveComponent implements OnInit {
         break
       case TransactionMetadataDAOCoinLimitOrder:
         const daoCoinLimitOrderMetadata = this.transaction.metadata as TransactionMetadataDAOCoinLimitOrder;
-        if (daoCoinLimitOrderMetadata.cancelOrderID.length != 0) {
+        if (daoCoinLimitOrderMetadata.cancelOrderID != null &&
+          daoCoinLimitOrderMetadata.cancelOrderID.length != 0) {
+
           // The transaction is cancelling an existing limit order
           const orderId = daoCoinLimitOrderMetadata.cancelOrderID.toString('hex');
           description = `cancel DAO coin limit order with OrderID: ${orderId}`;
@@ -328,6 +330,7 @@ export class ApproveComponent implements OnInit {
             description = `create a DAO coin limit order to buy ${quantityToFill} ${buyingCoin} with an ` +
               `exchange rate of ${exchangeRate} ${sellingCoin} per coin bought`;
           }
+          // FIXME: You always need to catch the error case!
         }
         break;
     }

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -282,14 +282,12 @@ export class ApproveComponent implements OnInit {
         break
       case TransactionMetadataDAOCoinLimitOrder:
         const daoCoinLimitOrderMetadata = this.transaction.metadata as TransactionMetadataDAOCoinLimitOrder;
-        if (daoCoinLimitOrderMetadata.cancelOrderID != null &&
-          daoCoinLimitOrderMetadata.cancelOrderID.length != 0) {
-
+        if (daoCoinLimitOrderMetadata.cancelOrderID != null && daoCoinLimitOrderMetadata.cancelOrderID.length != 0) {
           // The transaction is cancelling an existing limit order
           const orderId = daoCoinLimitOrderMetadata.cancelOrderID.toString('hex');
-          description = `cancel DAO coin limit order with OrderID: ${orderId}`;
+          description = `cancel the DAO coin limit order with OrderID: ${orderId}`;
         } else {
-          // The transaction is creating a new limit order
+          // The transaction must be creating a new limit order
           publicKeys = [];
 
           let buyingCoin = '$DESO';
@@ -329,8 +327,14 @@ export class ApproveComponent implements OnInit {
             const exchangeRate = this.toFixedLengthDecimalString(exchangeRateCoinsToSellPerCoinToBuy);
             description = `create a DAO coin limit order to buy ${quantityToFill} ${buyingCoin} with an ` +
               `exchange rate of ${exchangeRate} ${sellingCoin} per coin bought`;
+          } else {
+            // Operation type is unknown, but we'll still try to interpret the order as best we can, and let the user
+            // decide what to do
+            const exchangeRate = this.toFixedLengthDecimalString(exchangeRateCoinsToSellPerCoinToBuy);
+            description = `create a DAO coin limit order with unknown OperationType=${daoCoinLimitOrderOperationType} ` +
+              `to swap ${sellingCoin} for ${buyingCoin} at an exchange rate of ${exchangeRate} and a quantity of ` +
+              `${quantityToFill}`;
           }
-          // FIXME: You always need to catch the error case!
         }
         break;
     }

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -296,14 +296,14 @@ export class ApproveComponent implements OnInit {
           // If the buying coin's public key is a zero byte array, then it means the is $DESO. Otherwise, it's a DAO coin
           if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)) {
             const buyingCoinPublicKey = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey);
-            buyingCoin = buyingCoinPublicKey + ' DAO coin';
+            buyingCoin = buyingCoinPublicKey + ' DAO coins';
             publicKeys.push(buyingCoinPublicKey);
           }
 
           // Similar to the above, a zero byte array means that $DESO is being sold. Otherwise, it's a DAO coin
           if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey)) {
             const sellingCoinPublicKey = this.base58KeyCheck(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey);
-            sellingCoin = sellingCoinPublicKey + ' DAO coin';
+            sellingCoin = sellingCoinPublicKey + ' DAO coins';
             publicKeys.push(sellingCoinPublicKey);
           }
 

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -33,7 +33,8 @@ import {
   TransactionMetadataMessagingGroup,
   TransactionMetadataDAOCoin,
   TransactionMetadataTransferDAOCoin,
-  TransactionSpendingLimit
+  TransactionSpendingLimit,
+  TransactionMetadataDAOCoinLimitOrder,
 } from '../../lib/deso/transaction';
 import bs58check from 'bs58check';
 
@@ -279,6 +280,56 @@ export class ApproveComponent implements OnInit {
         const groupKeyName = messagingGroupMetadata.messagingGroupKeyName
         description = `register group key with name "${groupKeyName}"`
         break
+      case TransactionMetadataDAOCoinLimitOrder:
+        const daoCoinLimitOrderMetadata = this.transaction.metadata as TransactionMetadataDAOCoinLimitOrder;
+        if (daoCoinLimitOrderMetadata.cancelOrderID.length != 0) {
+          // The transaction is cancelling an existing limit order
+          const orderId = daoCoinLimitOrderMetadata.cancelOrderID.toString('hex');
+          description = `cancel DAO coin limit order with OrderID: ${orderId}`;
+        } else {
+          // The transaction is creating a new limit order
+          publicKeys = [];
+
+          let buyingCoin = '$DESO';
+          let sellingCoin = '$DESO';
+
+          // If the buying coin's public key is a zero byte array, then it means the is $DESO. Otherwise, it's a DAO coin
+          if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)) {
+            const buyingCoinName = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)
+            buyingCoin = buyingCoinName + ' coins';
+            publicKeys.push(buyingCoinName);
+          }
+
+          // Similar to the above, a zero buy array means that $DESO is being sold. Otherwise, it's a DAO coin
+          if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey)) {
+            const sellingCoinName = this.base58KeyCheck(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey);
+            sellingCoin = sellingCoinName + ' coins';
+            publicKeys.push(sellingCoinName);
+          }
+
+          const exchangeRateCoinsToSellPerCoinToBuy = this.hexScaledExchangeRateToFloat(
+            daoCoinLimitOrderMetadata.scaledExchangeRateCoinsToSellPerCoinToBuy,
+          );
+          const quantityToFill = this.hexNanosToUnitString(daoCoinLimitOrderMetadata.quantityToFillInBaseUnits);
+
+          const daoCoinLimitOrderOperationType = daoCoinLimitOrderMetadata.operationType.toString();
+
+          if (daoCoinLimitOrderOperationType == '1') {
+            // -- ASK Order --
+            // Here, we invert the exchange rate so that the denominator refers to the coin being sold. This way the
+            // messaging for the user can easily verity quantity of coins being sold, and the price rate per coin
+            const exchangeRate = this.toFixedLengthDecimalString(1 / exchangeRateCoinsToSellPerCoinToBuy);
+            description = `create a DAO coin limit order to sell ${quantityToFill} ${sellingCoin} with an ` +
+              `exchange rate of ${exchangeRate} ${buyingCoin} per coin`;
+            break;
+          } else if (daoCoinLimitOrderOperationType == '2') {
+            // -- BID Order --
+            const exchangeRate = this.toFixedLengthDecimalString(exchangeRateCoinsToSellPerCoinToBuy);
+            description = `create a DAO coin limit order to buy ${quantityToFill} ${buyingCoin} with an ` +
+              `exchange rate of ${exchangeRate} ${sellingCoin} per coin`;
+          }
+        }
+        break;
     }
 
     // Set the transaction description based on the description populated with public keys.
@@ -301,9 +352,21 @@ export class ApproveComponent implements OnInit {
   }
 
   nanosToUnitString(nanos: number): string {
+    return this.toFixedLengthDecimalString((nanos / 1e9));
+  }
+
+  hexScaledExchangeRateToFloat(hex: Buffer): number {
+    return parseInt(hex.toString('hex'), 16) / 1e38;
+  }
+
+  toFixedLengthDecimalString(num: number): string {
     // Change nanos into a formatted string of units. This combination of toFixed and regex removes trailing zeros.
     // If we do a regular toString(), some numbers can be represented in E notation which doesn't look as good.
-    return (nanos / 1e9).toFixed(9).replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/,'$1');
+    return num.toFixed(9).replace(/([0-9]+(\.[0-9]+[1-9])?)(\.?0+$)/, '$1');
+  }
+
+  isZeroByteArray(buffer: Buffer): boolean {
+    return parseInt(buffer.toString('hex'), 16) == 0;
   }
 
   // Fetch Usernames from API and replace public keys in description with Username

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -295,16 +295,16 @@ export class ApproveComponent implements OnInit {
 
           // If the buying coin's public key is a zero byte array, then it means the is $DESO. Otherwise, it's a DAO coin
           if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)) {
-            const buyingCoinName = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey);
-            buyingCoin = buyingCoinName + ' coins';
-            publicKeys.push(buyingCoinName);
+            const buyingCoinPublicKey = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey);
+            buyingCoin = buyingCoinPublicKey + ' DAO coin';
+            publicKeys.push(buyingCoinPublicKey);
           }
 
-          // Similar to the above, a zero buy array means that $DESO is being sold. Otherwise, it's a DAO coin
+          // Similar to the above, a zero byte array means that $DESO is being sold. Otherwise, it's a DAO coin
           if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey)) {
-            const sellingCoinName = this.base58KeyCheck(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey);
-            sellingCoin = sellingCoinName + ' coins';
-            publicKeys.push(sellingCoinName);
+            const sellingCoinPublicKey = this.base58KeyCheck(daoCoinLimitOrderMetadata.sellingDAOCoinCreatorPublicKey);
+            sellingCoin = sellingCoinPublicKey + ' DAO coin';
+            publicKeys.push(sellingCoinPublicKey);
           }
 
           const exchangeRateCoinsToSellPerCoinToBuy = this.hexScaledExchangeRateToFloat(
@@ -320,13 +320,13 @@ export class ApproveComponent implements OnInit {
             // can easily verify the quantity of coins being sold, and the exchange rate per coin sold
             const exchangeRate = this.toFixedLengthDecimalString(1 / exchangeRateCoinsToSellPerCoinToBuy);
             description = `create a DAO coin limit order to sell ${quantityToFill} ${sellingCoin} with an ` +
-              `exchange rate of ${exchangeRate} ${buyingCoin} per coin`;
+              `exchange rate of ${exchangeRate} ${buyingCoin} per coin sold`;
             break;
           } else if (daoCoinLimitOrderOperationType == '2') {
             // -- BID Order --
             const exchangeRate = this.toFixedLengthDecimalString(exchangeRateCoinsToSellPerCoinToBuy);
             description = `create a DAO coin limit order to buy ${quantityToFill} ${buyingCoin} with an ` +
-              `exchange rate of ${exchangeRate} ${sellingCoin} per coin`;
+              `exchange rate of ${exchangeRate} ${sellingCoin} per coin bought`;
           }
         }
         break;
@@ -352,7 +352,7 @@ export class ApproveComponent implements OnInit {
   }
 
   nanosToUnitString(nanos: number): string {
-    return this.toFixedLengthDecimalString((nanos / 1e9));
+    return this.toFixedLengthDecimalString(nanos / 1e9);
   }
 
   hexScaledExchangeRateToFloat(hex: Buffer): number {

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -293,7 +293,7 @@ export class ApproveComponent implements OnInit {
           let buyingCoin = '$DESO';
           let sellingCoin = '$DESO';
 
-          // If the buying coin's public key is a zero byte array, then it means the is $DESO. Otherwise, it's a DAO coin
+          // If the buying coin's public key is a zero byte array, then the coin is $DESO. Otherwise, it's a DAO coin
           if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)) {
             const buyingCoinPublicKey = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey);
             buyingCoin = buyingCoinPublicKey + ' DAO coins';

--- a/src/app/approve/approve.component.ts
+++ b/src/app/approve/approve.component.ts
@@ -277,8 +277,8 @@ export class ApproveComponent implements OnInit {
         break;
       case TransactionMetadataMessagingGroup:
         const messagingGroupMetadata = this.transaction.metadata as TransactionMetadataMessagingGroup;
-        const groupKeyName = messagingGroupMetadata.messagingGroupKeyName
-        description = `register group key with name "${groupKeyName}"`
+        const groupKeyName = messagingGroupMetadata.messagingGroupKeyName;
+        description = `register group key with name "${groupKeyName}"`;
         break
       case TransactionMetadataDAOCoinLimitOrder:
         const daoCoinLimitOrderMetadata = this.transaction.metadata as TransactionMetadataDAOCoinLimitOrder;
@@ -295,7 +295,7 @@ export class ApproveComponent implements OnInit {
 
           // If the buying coin's public key is a zero byte array, then it means the is $DESO. Otherwise, it's a DAO coin
           if (!this.isZeroByteArray(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)) {
-            const buyingCoinName = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey)
+            const buyingCoinName = this.base58KeyCheck(daoCoinLimitOrderMetadata.buyingDAOCoinCreatorPublicKey);
             buyingCoin = buyingCoinName + ' coins';
             publicKeys.push(buyingCoinName);
           }
@@ -316,8 +316,8 @@ export class ApproveComponent implements OnInit {
 
           if (daoCoinLimitOrderOperationType == '1') {
             // -- ASK Order --
-            // Here, we invert the exchange rate so that the denominator refers to the coin being sold. This way the
-            // messaging for the user can easily verity quantity of coins being sold, and the price rate per coin
+            // Here, we invert the exchange rate so that the denominator refers to the coin being sold. This way the user
+            // can easily verify the quantity of coins being sold, and the exchange rate per coin sold
             const exchangeRate = this.toFixedLengthDecimalString(1 / exchangeRateCoinsToSellPerCoinToBuy);
             description = `create a DAO coin limit order to sell ${quantityToFill} ${sellingCoin} with an ` +
               `exchange rate of ${exchangeRate} ${buyingCoin} per coin`;

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -33,7 +33,7 @@ import {
   TransactionMetadataCreateNFT,
   TransactionMetadataDAOCoin,
   TransactionMetadataTransferDAOCoin,
-  TransactionSpendingLimit
+  TransactionMetadataDAOCoinLimitOrder
 } from '../lib/deso/transaction';
 
 export type DerivePayload = {
@@ -290,6 +290,7 @@ export class IdentityService {
       case TransactionMetadataAuthorizeDerivedKey:
       case TransactionMetadataDAOCoin:
       case TransactionMetadataTransferDAOCoin:
+      case TransactionMetadataDAOCoinLimitOrder:
         return AccessLevel.Full;
 
       case TransactionMetadataFollow:

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -33,7 +33,7 @@ import {
   TransactionMetadataCreateNFT,
   TransactionMetadataDAOCoin,
   TransactionMetadataTransferDAOCoin,
-  TransactionMetadataDAOCoinLimitOrder
+  TransactionMetadataDAOCoinLimitOrder,
 } from '../lib/deso/transaction';
 
 export type DerivePayload = {

--- a/src/lib/deso/transaction.ts
+++ b/src/lib/deso/transaction.ts
@@ -402,6 +402,37 @@ export class TransactionSpendingLimit extends BinaryRecord {
   nftOperationLimitMap: TransactionNFTOperationLimitMapItem[] = [];
 }
 
+export class DeSoInputsByTransactor extends BinaryRecord {
+  @Transcode(FixedBuffer(33))
+  transactorPublicKey: Buffer = Buffer.alloc(0);
+
+  @Transcode(ArrayOf(TransactionInput))
+  inputs: TransactionInput[] = [];
+}
+
+export class TransactionMetadataDAOCoinLimitOrder extends BinaryRecord {
+  @Transcode(VarBuffer)
+  buyingDAOCoinCreatorPublicKey: Buffer = Buffer.alloc(0);
+
+  @Transcode(VarBuffer)
+  sellingDAOCoinCreatorPublicKey: Buffer = Buffer.alloc(0);
+
+  @Transcode(VarBuffer)
+  scaledExchangeRateCoinsToSellPerCoinToBuy: Buffer = Buffer.alloc(0);
+
+  @Transcode(VarBuffer)
+  quantityToFillInBaseUnits: Buffer = Buffer.alloc(0);
+
+  @Transcode(Uvarint64)
+  operationType: Buffer = Buffer.alloc(0);
+
+  @Transcode(VarBuffer)
+  cancelOrderID: Buffer = Buffer.alloc(0);
+
+  @Transcode(ArrayOf(DeSoInputsByTransactor))
+  bidderInputs: DeSoInputsByTransactor[] = [];
+}
+
 export const TransactionTypeMetadataMap = {
   1: TransactionMetadataBlockReward,
   2: TransactionMetadataBasicTransfer,
@@ -427,6 +458,7 @@ export const TransactionTypeMetadataMap = {
   23: TransactionMetadataMessagingGroup,
   24: TransactionMetadataDAOCoin,
   25: TransactionMetadataTransferDAOCoin,
+  26: TransactionMetadataDAOCoinLimitOrder,
 };
 
 export class Transaction extends BinaryRecord {


### PR DESCRIPTION
 This adds support for limit order transaction in identity, and address comments from previous RFC PR (https://github.com/deso-protocol/identity/pull/123/files).

Test Plan

Cancelling an order
<img width="1029" alt="image" src="https://user-images.githubusercontent.com/99746187/163834910-1c513dc6-a05d-4394-aab8-8463fd379701.png">

Submitted an order to sell 3 DAO coins for 4 $DESO each
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/99746187/163835012-8a13690d-97ce-479a-aa42-1f2446ecec9a.png">

Submitted an order to buy 1 DAO coin for 0.1 $DESO each
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/99746187/163835085-730f7289-2f9b-4813-9b79-18c17338b385.png">

Submitting an order with unknown operation type w/ exchange rate of 0.1 and quantity of 1
<img width="1082" alt="image" src="https://user-images.githubusercontent.com/99746187/163835253-4a0fe62c-7949-4253-8b45-19aa57cd3c53.png">