### PR TITLE
Derive call should only happen on derive route, fix derive flow when user needs to create an account

### DIFF
--- a/src/app/account.service.ts
+++ b/src/app/account.service.ts
@@ -174,7 +174,8 @@ export class AccountService {
       messagingPrivateKey,
       messagingKeyName,
       messagingKeySignature,
-      transactionSpendingLimitHex
+      transactionSpendingLimitHex,
+      signedUp: this.globalVars.signedUp,
     };
   }
 

--- a/src/app/auth/google/google.component.ts
+++ b/src/app/auth/google/google.component.ts
@@ -137,9 +137,8 @@ export class GoogleComponent implements OnInit {
     this.accountService.setAccessLevel(this.publicKey, this.globalVars.hostname, this.globalVars.accessLevelRequest);
 
     if (this.globalVars.derive) {
-      this.identityService.derive({
-        publicKey: this.publicKey,
-      });
+      this.router.navigate(['/', RouteNames.DERIVE],
+        { queryParams: { publicKey: this.publicKey }, queryParamsHandling: 'merge'});
     } else {
       if (!this.globalVars.getFreeDeso) {
         this.login(signedUp);

--- a/src/app/buy-or-send-deso/buy-or-send-deso.component.ts
+++ b/src/app/buy-or-send-deso/buy-or-send-deso.component.ts
@@ -107,9 +107,8 @@ export class BuyOrSendDesoComponent implements OnInit {
   ////// FINISH FLOW ///////
   finishFlow(): void {
     if (this.globalVars.derive) {
-      this.identityService.derive({
-        publicKey: this.publicKeyAdded,
-      });
+      this.router.navigate(['/', RouteNames.DERIVE],
+        { queryParams: { publicKey: this.publicKeyAdded }, queryParamsHandling: 'merge' });
     } else {
       this.login();
     }

--- a/src/app/derive/derive.component.ts
+++ b/src/app/derive/derive.component.ts
@@ -106,19 +106,19 @@ export class DeriveComponent implements OnInit {
   }
 
   selectAccountAndDeriveKey(publicKey: string): void {
-    this.identityService.derive({
-      publicKey,
-      transactionSpendingLimitHex: this.transactionSpendingLimitHex,
-      expirationDays: this.expirationDays,
-    });
+    this.derive(publicKey);
   }
 
   approveDerivedKey(): void {
     if (!this.publicKeyBase58Check) {
       return;
     }
+    this.derive(this.publicKeyBase58Check);
+  }
+
+  derive(publicKey: string): void {
     this.identityService.derive({
-      publicKey: this.publicKeyBase58Check,
+      publicKey,
       derivedPublicKey: this.derivedPublicKeyBase58Check,
       transactionSpendingLimitHex: this.transactionSpendingLimitHex,
       expirationDays: this.expirationDays,

--- a/src/app/get-deso/get-deso.component.ts
+++ b/src/app/get-deso/get-deso.component.ts
@@ -131,9 +131,8 @@ export class GetDesoComponent implements OnInit {
   ////// FINISH FLOW ///////
   finishFlow(): void {
     if (this.globalVars.derive) {
-      this.identityService.derive({
-        publicKey: this.publicKeyAdded,
-      });
+      this.router.navigate(['/', RouteNames.DERIVE],
+        { queryParams: { publicKey: this.publicKeyAdded }, queryParamsHandling: 'merge' });
     } else {
       this.login();
     }

--- a/src/app/log-in-seed/log-in-seed.component.ts
+++ b/src/app/log-in-seed/log-in-seed.component.ts
@@ -64,7 +64,6 @@ export class LogInSeedComponent implements OnInit {
 
     // NOTE: Temporary support for 1 in 128 legacy users who have non-standard derivations
     if (keychain.publicKey !== keychainNonStandard.publicKey) {
-      const network = this.globalVars.network;
       const seedHex = this.cryptoService.keychainToSeedHex(keychainNonStandard);
       const privateKey = this.cryptoService.seedHexToPrivateKey(seedHex);
       const publicKey = this.cryptoService.privateKeyToDeSoPublicKey(privateKey, network);
@@ -87,9 +86,8 @@ export class LogInSeedComponent implements OnInit {
     this.extraText = '';
 
     if (this.globalVars.derive) {
-      this.identityService.derive({
-        publicKey: userPublicKey,
-      });
+      this.router.navigate(['/', RouteNames.DERIVE],
+        { queryParams: { publicKey: userPublicKey }, queryParamsHandling: 'merge'});
     } else {
       this.router.navigate(['/', RouteNames.LOG_IN], {queryParamsHandling: 'merge'});
     }

--- a/src/app/sign-up/sign-up.component.ts
+++ b/src/app/sign-up/sign-up.component.ts
@@ -118,6 +118,11 @@ export class SignUpComponent implements OnInit, OnDestroy {
       this.router.navigate(['/', RouteNames.GET_DESO], {
         queryParams: {publicKey: this.publicKeyAdded, signedUp: true },
         queryParamsHandling: 'merge'});
+    } else if (this.globalVars.derive) {
+      this.globalVars.signedUp = true;
+      this.router.navigate(['/', RouteNames.DERIVE], {
+        queryParams: {publicKey: this.publicKeyAdded, signedUp: true},
+        queryParamsHandling: 'merge'});
     } else {
       this.identityService.login({
         users: this.accountService.getEncryptedUsers(),

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -46,6 +46,7 @@ export interface DerivedPrivateUserInfo {
   messagingKeyName: string;
   messagingKeySignature: string;
   transactionSpendingLimitHex: string | undefined;
+  signedUp: boolean;
 }
 
 export interface UserProfile {


### PR DESCRIPTION
This will resolve #139 

Basically we weren't redirecting the user to the derive page after completing the sign-up flow with a new seed phrase. This update also redirects users to the derive page again from any flow. This ensures that the user explicitly approves a derived key - before a user could arrive at the derive page and then log into an existing account with a seed and that would automatically send the derive message back to the client. 