### PR TITLE
fix: add a status for the storage granted payload

### DIFF
--- a/src/app/embed/embed.component.ts
+++ b/src/app/embed/embed.component.ts
@@ -15,7 +15,17 @@ export class EmbedComponent {
     }
 
     document.requestStorageAccess().then(() => {
-      this.identityService.storageGranted();
+      this.identityService.storageGranted(true);
+    }).catch(() => {
+      // This can fail in at least 2 cases (maybe more):
+      // 1. In some cases, the user's browser shows a native confirmation prompt after they tap the embed
+      //    asking if they allow or deny access to cookies and local storage. If the user chooses not to allow
+      //    access, the requestStorageAccess promise will reject. If this rejected promise is not handled, the
+      //    the embed will appear "stuck" and the user cannot exit it without reloading the page.
+      // 2. The embed does not have "first-party" status according to the browser. This is a bit involved for
+      //    to explain here but see this github issue comment for more information
+      //    https://github.com/deso-protocol/deso-workspace/issues/17#issuecomment-1247387525.
+      this.identityService.storageGranted(false);
     });
   }
 }

--- a/src/app/identity.service.ts
+++ b/src/app/identity.service.ts
@@ -98,8 +98,13 @@ export class IdentityService {
     return this.send('initialize', {});
   }
 
-  storageGranted(): void {
-    this.cast('storageGranted');
+  /**
+   * @param status whether or not the user confirmed access to storage.
+   */
+  storageGranted(status: boolean): void {
+    this.cast('storageGranted', {
+      status,
+    });
   }
 
   login(payload: {


### PR DESCRIPTION
Addresses the bug report on the deso-protocol library: https://github.com/deso-protocol/deso-workspace/issues/17#issuecomment-1195791915

In some cases, the `requestStorageAccess` promise can reject. If the host page is not notified of the failure, the iframe appears "stuck" since the host app is never notified via `postMessage` that the access request has failed. The error is just swallowed and the user cannot recover without reloading the page.

Here I've just added a `status` field to the payload that indicates whether access has been successfully granted or not. Calling apps can look at the status to determine how to proceed (show an error message, etc).

This should not be a breaking change since its a new field and none of the public apis or `postMessage` methods have been changed.

I tested this against the metamask mobile builtin browser. Ran their app locally and hooked a debugger to the webview, etc.

Example of the prompt where users can accept or deny access:
<img width="295" alt="Screen Shot 2022-09-14 at 7 11 32 PM" src="https://user-images.githubusercontent.com/7357287/190300466-cee3875a-e5a4-40c5-ada1-45fbe50d1cd0.png">