### PR TITLE
fix: keep track of previous user info for multiple metamask logins

### DIFF
--- a/src/app/account.service.ts
+++ b/src/app/account.service.ts
@@ -941,6 +941,27 @@ export class AccountService {
       );
     }
 
+    // In the case of a metamask login, we generate a new derived key and
+    // deposit addresses for the user. In order to recover funds sent to an old
+    // deposit address, we keep a record of the old derived info.
+    if (privateUsers[publicKey]?.derivedPublicKeyBase58Check && privateUsers[publicKey]?.derivedPublicKeyBase58Check !== userInfo.derivedPublicKeyBase58Check) {
+      const previousUserInfo = privateUsers[publicKey];
+      const archivedUserData = JSON.parse(window.localStorage.getItem("archivedUserData") ?? "{}");
+
+      if (Array.isArray(archivedUserData[publicKey])) {
+        archivedUserData[publicKey].push(previousUserInfo);
+
+        // messagingKeyRandomness is deterministic, so if they've generated it at least once before, we can just use that for any new login attempts.
+        const existingMessagingKeyRandomness = archivedUserData[publicKey].find((u: any) => !!u.messagingKeyRandomness)?.messagingKeyRandomness;
+        if (existingMessagingKeyRandomness && !userInfo.messagingKeyRandomness) {
+          userInfo.messagingKeyRandomness = existingMessagingKeyRandomness;
+        }
+      } else {
+        archivedUserData[publicKey] = [previousUserInfo];
+      }
+      window.localStorage.setItem("archivedUserData", JSON.stringify(archivedUserData));
+    }
+
     privateUsers[publicKey] = userInfo;
 
     this.setPrivateUsersRaw(privateUsers);


### PR DESCRIPTION
When a user logs in with metamask we generate a new derived key and new deposit addresses. Previously we were keeping track of only the most recent login data and overwriting any previous data with it. This makes it such that we keep an "archive" of the previous derived information in case we need it for support in the future.

This also makes it such that we re-use any previously generated messaging key randomness since this is a deterministic value. This prevents metamask users from needing to approve a new messaging key each time they log in.