### PR TITLE
hide skip button by default

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -77,10 +77,13 @@ export class AppComponent implements OnInit {
 
     this.globalVars.redirectURI = params.get('redirect_uri') ?? stateParamsFromGoogle.redirect_uri ?? '';
 
-    if (
-      params.get('derive') === 'true' ||
-      stateParamsFromGoogle.derive
-    ) {
+    const showSkip = params.get('showSkip');
+    this.globalVars.showSkip =
+      (showSkip && JSON.parse(showSkip)) ??
+      stateParamsFromGoogle.showSkip ??
+      false;
+
+    if (params.get('derive') === 'true' || stateParamsFromGoogle.derive) {
       this.globalVars.derive = true;
     }
 

--- a/src/app/auth/google/google.component.ts
+++ b/src/app/auth/google/google.component.ts
@@ -228,6 +228,7 @@ export const getStateParamsFromGoogle = (
     derivedPublicKey: '',
     expirationDays: 0,
     redirect_uri: '',
+    showSkip: false,
   };
 
   try {

--- a/src/app/get-deso/get-deso.component.html
+++ b/src/app/get-deso/get-deso.component.html
@@ -45,6 +45,7 @@
         Transfer from an exchange or a DeSo account
       </div>
       <button
+        *ngIf="this.globalVars.showSkip"
         (click)="finishFlow()"
         [ngStyle]="{
           width: '40%',

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -58,6 +58,11 @@ export class GlobalVarsService {
 
   redirectURI = '';
 
+  /**
+   * If true, the "Skip" button will be shown on the get deso page.
+   */
+  showSkip: boolean = false;
+
   isFullAccessHostname(): boolean {
     return GlobalVarsService.fullAccessHostnames.includes(this.hostname);
   }

--- a/src/app/google-drive.service.ts
+++ b/src/app/google-drive.service.ts
@@ -96,6 +96,7 @@ export class GoogleDriveService {
       deleteKey: this.globalVars.deleteKey,
       expirationDays: this.globalVars.expirationDays,
       redirect_uri: this.globalVars.redirectURI,
+      showSkip: this.globalVars.showSkip,
     };
 
     const stateString = btoa(JSON.stringify(stateParams));

--- a/src/types/identity.ts
+++ b/src/types/identity.ts
@@ -139,4 +139,5 @@ export interface GoogleAuthState {
   derivedPublicKey: string;
   expirationDays: number;
   redirect_uri?: string;
+  showSkip: boolean;
 }


### PR DESCRIPTION
The goal here is to prevent users from completing a login flow successfully without getting some amount of deso. These seems fine since we provide both the phone number verification and an anonymous buy flow. We've added a param to allow applications to show the skip button if this presents any issues.