### PR TITLE
display count values >= 1e9 as UNLIMITED

### DIFF
--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -160,7 +160,7 @@ export class GlobalVarsService {
   }
 
   // If the count is 1 billion or more, it will be displayed as "UNLIMITED"
-  // Otherwise, it will be displayed as a delimited number based on the users locale.
+  // Otherwise, it will be displayed as a delimited number based on the user's locale.
   formatTxCountLimit(count: number = 0): string {
     return count >= 1e9 ? 'UNLIMITED' : count.toLocaleString();
   }

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -158,4 +158,9 @@ export class GlobalVarsService {
       )
       .join(' ');
   }
+
+  // If the count is 1 billion or more, it will be displayed as "UNLIMITED"
+  formatTxCountLimit(count: number = 0): string {
+    return count >= 1e9 ? 'UNLIMITED' : count.toString();
+  }
 }

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -160,7 +160,8 @@ export class GlobalVarsService {
   }
 
   // If the count is 1 billion or more, it will be displayed as "UNLIMITED"
+  // Otherwise, it will be displayed as a delimited number based on the users locale.
   formatTxCountLimit(count: number = 0): string {
-    return count >= 1e9 ? 'UNLIMITED' : count.toString();
+    return count >= 1e9 ? 'UNLIMITED' : count.toLocaleString();
   }
 }

--- a/src/app/transaction-spending-limit/transaction-spending-limit-access-group-member/transaction-spending-limit-access-group-member.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-access-group-member/transaction-spending-limit-access-group-member.component.html
@@ -4,7 +4,7 @@
       {{ getOperationString() }}{{ !isScoped() ? ' any of' : '' }}
       {{ (appUser?.ProfileEntryResponse?.Username || accessGroupMemberLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername)}}'s
       access group{{ isScoped() ? ' "' + accessGroupMemberLimitMapItem?.AccessGroupKeyName + '"' : 's' }}
-      ({{ accessGroupMemberLimitMapItem?.OpCount }}x).
+      ({{ globalVars.formatTxCountLimit(accessGroupMemberLimitMapItem?.OpCount) }}x).
     </div>
   </div>
 </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-access-group-member/transaction-spending-limit-access-group-member.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-access-group-member/transaction-spending-limit-access-group-member.component.html
@@ -4,7 +4,7 @@
       {{ getOperationString() }}{{ !isScoped() ? ' any of' : '' }}
       {{ (appUser?.ProfileEntryResponse?.Username || accessGroupMemberLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername)}}'s
       access group{{ isScoped() ? ' "' + accessGroupMemberLimitMapItem?.AccessGroupKeyName + '"' : 's' }}
-      ({{ globalVars.formatTxCountLimit(accessGroupMemberLimitMapItem?.OpCount) }}x).
+      ({{ globalVars.formatTxCountLimit(accessGroupMemberLimitMapItem?.OpCount) }} times).
     </div>
   </div>
 </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-access-group/transaction-spending-limit-access-group.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-access-group/transaction-spending-limit-access-group.component.html
@@ -4,7 +4,7 @@
       {{ getOperationString() }}{{ !isScoped() ? ' any of' : '' }}
       {{ (appUser?.ProfileEntryResponse?.Username || accessGroupLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername)}}'s
       access group{{ isScoped() ? ' "' + accessGroupLimitMapItem?.AccessGroupKeyName + '"' : 's' }}
-      ({{ accessGroupLimitMapItem?.OpCount }}x).
+      ({{ globalVars.formatTxCountLimit(accessGroupLimitMapItem?.OpCount) }}x).
     </div>
   </div>
 </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-access-group/transaction-spending-limit-access-group.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-access-group/transaction-spending-limit-access-group.component.html
@@ -4,7 +4,7 @@
       {{ getOperationString() }}{{ !isScoped() ? ' any of' : '' }}
       {{ (appUser?.ProfileEntryResponse?.Username || accessGroupLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername)}}'s
       access group{{ isScoped() ? ' "' + accessGroupLimitMapItem?.AccessGroupKeyName + '"' : 's' }}
-      ({{ globalVars.formatTxCountLimit(accessGroupLimitMapItem?.OpCount) }}x).
+      ({{ globalVars.formatTxCountLimit(accessGroupLimitMapItem?.OpCount) }} times).
     </div>
   </div>
 </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-association/transaction-spending-limit-association.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-association/transaction-spending-limit-association.component.html
@@ -2,7 +2,7 @@
   <div class="d-flex justify-content-between align-items-center">
       <div class="d-flex justify-content-start align-items-center py-10px col-12">
         {{ getOperationString() }}
-        {{ associationLimitMapItem?.OpCount }}
+        {{ globalVars.formatTxCountLimit(associationLimitMapItem?.OpCount) }}
         {{ associationLimitMapItem?.AssociationClass }}
         {{ associationLimitMapItem?.AssociationType }}
         associations on

--- a/src/app/transaction-spending-limit/transaction-spending-limit-coin/transaction-spending-limit-coin.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-coin/transaction-spending-limit-coin.component.html
@@ -40,7 +40,7 @@
       }"
     >
       <div>{{ globalVars.cleanSpendingLimitOperationName(opLimit.key) }}</div>
-      <div>{{ opLimit.value }}</div>
+      <div>{{ globalVars.formatTxCountLimit(opLimit.value) }}</div>
     </div>
   </div>
 </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-dao-coin-limit-order/transaction-spending-limit-dao-coin-limit-order.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-dao-coin-limit-order/transaction-spending-limit-dao-coin-limit-order.component.html
@@ -40,7 +40,7 @@
       </div>
     </div>
     <div class="d-flex col-2 align-items-center justify-content-center">
-      <div>{{ daoCoinLimitOrderLimitItem?.OpCount }}</div>
+      <div>{{ globalVars.formatTxCountLimit(daoCoinLimitOrderLimitItem?.OpCount) }}</div>
     </div>
   </div>
 </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-dao-coin-limit-order/transaction-spending-limit-dao-coin-limit-order.component.ts
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-dao-coin-limit-order/transaction-spending-limit-dao-coin-limit-order.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { GlobalVarsService } from 'src/app/global-vars.service';
 import { DAOCoinLimitOrderLimitItem, User } from '../../backend-api.service';
 import { TransactionSpendingLimitComponent } from '../transaction-spending-limit.component';
 
@@ -17,6 +18,8 @@ export class TransactionSpendingLimitDaoCoinLimitOrderComponent
   @Input() buyingUser: User | undefined;
   @Input() sellingUser: User | undefined;
   TransactionSpendingLimitComponent = TransactionSpendingLimitComponent;
+
+  constructor(public globalVars: GlobalVarsService) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/transaction-spending-limit/transaction-spending-limit-nft/transaction-spending-limit-nft.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-nft/transaction-spending-limit-nft.component.html
@@ -110,7 +110,7 @@
           <div>
             {{ globalVars.cleanSpendingLimitOperationName(opLimit.key) }}
           </div>
-          <div>{{ opLimit.value }}</div>
+          <div>{{ globalVars.formatTxCountLimit(opLimit.value) }}</div>
         </div>
       </div>
     </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-section/transaction-spending-limit-section.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-section/transaction-spending-limit-section.component.html
@@ -46,8 +46,7 @@
           <div>
             {{ globalVars.cleanSpendingLimitOperationName(txnLimitItem.key) }}
           </div>
-          <!-- NOTE: If the count is 1 million or more, it will be displayed as "UNLIMITED" -->
-          <div>{{ txnLimitItem.value >= 1e9 ? 'UNLIMITED' : txnLimitItem.value }}</div>
+          <div>{{ globalVars.formatTxCountLimit(txnLimitItem.value) }}</div>
         </div>
       </ng-container>
       <ng-container

--- a/src/app/transaction-spending-limit/transaction-spending-limit-section/transaction-spending-limit-section.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-section/transaction-spending-limit-section.component.html
@@ -46,7 +46,8 @@
           <div>
             {{ globalVars.cleanSpendingLimitOperationName(txnLimitItem.key) }}
           </div>
-          <div>{{ txnLimitItem.value }}</div>
+          <!-- NOTE: If the count is 1 million or more, it will be displayed as "UNLIMITED" -->
+          <div>{{ txnLimitItem.value >= 1e9 ? 'UNLIMITED' : txnLimitItem.value }}</div>
         </div>
       </ng-container>
       <ng-container


### PR DESCRIPTION
It's a common desire to want to set individual tx types to unlimited. We currently only have the ability to make all transactions unlimited or specify an explicit number per tx type. This makes it such that any value greater than or equal to 1 billion will get displayed as "UNLIMITED." This also matches the unlimited tx type we have implemented in [@deso-core/identity](https://github.com/deso-protocol/deso-workspace/blob/c517a1c64f75afcd3e97a8ae383a6e92131aa956/libs/identity/src/lib/permissions-utils.spec.ts#L6).

<img width="586" alt="Screenshot 2023-02-02 at 1 24 50 PM" src="https://user-images.githubusercontent.com/7357287/216453109-ea403f81-cedc-485f-b07c-a17180adc638.png">
