### PR TITLE
add better treatment for unlimited keys

### DIFF
--- a/src/app/derive/derive.component.html
+++ b/src/app/derive/derive.component.html
@@ -41,17 +41,9 @@
   <div *ngIf="transactionSpendingLimitResponse && publicKeyBase58Check" class="mb-40px">
     <app-transaction-spending-limit
       [transactionSpendingLimitResponse]="transactionSpendingLimitResponse"
+      [onApproveClick]="this.onApproveClick"
     ></app-transaction-spending-limit>
   </div>
-  <div></div>
-  <button
-    [disabled]="!publicKeyBase58Check"
-    class="button btn-primary button-large mb-20px text-white font-weight-bold"
-    (click)="approveDerivedKey(publicKeyBase58Check)"
-    *ngIf="publicKeyBase58Check"
-  >
-    Approve
-  </button>
 </div>
 <div class="container home-container" *ngIf="deleteKey">
   <div class="fs-18px mt-30px">

--- a/src/app/derive/derive.component.ts
+++ b/src/app/derive/derive.component.ts
@@ -41,6 +41,7 @@ export class DeriveComponent implements OnInit {
   isSingleAccount = false;
   validationErrors = false;
   blockHeight = 0;
+  onApproveClick = () => this.approveDerivedKey(this.publicKeyBase58Check);
 
   constructor(
     private accountService: AccountService,

--- a/src/app/transaction-spending-limit/transaction-spending-limit.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit.component.html
@@ -64,15 +64,26 @@
       ></app-transaction-spending-limit-section>
   </div>
 
-  <div *ngIf="transactionSpendingLimitResponse.IsUnlimited">
-    <div class="d-flex flex-column">
-      <div class="d-flex">
-        <div class="d-flex justify-content-start align-items-center col-5">
-          This key is unlimited.
-        </div>
-      </div>
-    </div>
+  <div class="mt-5">
+    <button
+      class="button btn-primary button-large text-white font-weight-bold"
+      (click)="this.onApproveClick()"
+    >
+      Approve
+    </button>
   </div>
+
+  <div class="mt-3 text-center" *ngIf="transactionSpendingLimitResponse?.IsUnlimited">
+    <div *ngIf="this.globalVars.isFullAccessHostname(); else elseBlock">
+      By clicking approve, you are granting <strong>{{ globalVars.hostname }}</strong> unlimited signing access for your account.
+    </div>
+    <ng-template #elseBlock>
+      <div class="warning-text">
+        By clicking approve, you are granting <strong>{{ globalVars.hostname }}</strong> unlimited signing access for your account.
+      </div>
+    </ng-template>
+  </div>
+
   <div *ngIf="transactionSpendingLimitResponse.DerivedKeyMemo">
     <div class="flex-grow-1 pt-15px"></div>
     <div class="py-15px mb-2">

--- a/src/app/transaction-spending-limit/transaction-spending-limit.component.ts
+++ b/src/app/transaction-spending-limit/transaction-spending-limit.component.ts
@@ -22,6 +22,7 @@ export class TransactionSpendingLimitComponent implements OnInit {
     {
       GlobalDESOLimit: 0,
     };
+  @Input() onApproveClick: () => void = () => {};
   hasUsers = false;
   userMap: { [k: string]: User } = {};
   showTransactions: boolean = false;


### PR DESCRIPTION
This adds a better treatment for unlimited derived key requests. Per issue [DESO-1067](https://linear.app/deso/issue/DESO-1067/re-imagine-the-desojs-library)

Treatment for full access hosts:
<img width="622" alt="Screenshot 2023-02-02 at 3 58 09 PM" src="https://user-images.githubusercontent.com/7357287/216478142-b3259bef-cf9e-4475-9a28-7eaa4be1707b.png">

Treatment for all other hosts:
<img width="627" alt="Screenshot 2023-02-02 at 3 54 39 PM" src="https://user-images.githubusercontent.com/7357287/216478193-041751df-2761-4c29-9f75-898429231288.png">

Treatment for regular approve without unlimited is unchanged:
<img width="703" alt="Screenshot 2023-02-02 at 3 55 54 PM" src="https://user-images.githubusercontent.com/7357287/216478414-4a6be9dc-0735-4266-a96b-56aab54f28e2.png">

