### PR TITLE
set the group owner public key to selected public key if it's the empty string

### DIFF
--- a/src/app/derive/derive.component.ts
+++ b/src/app/derive/derive.component.ts
@@ -119,6 +119,20 @@ export class DeriveComponent implements OnInit {
       });
       return;
     }
+    if (this.transactionSpendingLimitResponse?.AccessGroupLimitMap) {
+      this.transactionSpendingLimitResponse.AccessGroupLimitMap.forEach((agl) => {
+        if (!agl.AccessGroupOwnerPublicKeyBase58Check) {
+          agl.AccessGroupOwnerPublicKeyBase58Check = publicKey;
+        }
+      })
+    }
+    if (this.transactionSpendingLimitResponse?.AccessGroupMemberLimitMap) {
+      this.transactionSpendingLimitResponse.AccessGroupMemberLimitMap.forEach((agml) => {
+        if (!agml.AccessGroupOwnerPublicKeyBase58Check) {
+          agml.AccessGroupOwnerPublicKeyBase58Check = publicKey;
+        }
+      })
+    }
     this.identityService.derive({
       publicKey,
       derivedPublicKey: this.derivedPublicKeyBase58Check,

--- a/src/app/sign-up-get-starter-deso/sign-up-get-starter-deso.component.html
+++ b/src/app/sign-up-get-starter-deso/sign-up-get-starter-deso.component.html
@@ -8,7 +8,7 @@
     >
       <div *ngIf="globalVars.callback; else elseBlock">Continue</div>
       <ng-template #elseBlock
-        >Continue to {{ globalVars.hostname }}</ng-template
+        >Continue {{ !globalVars.derive ? "to " + globalVars.hostname : ""}}</ng-template
       >
     </button>
   </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-access-group-member/transaction-spending-limit-access-group-member.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-access-group-member/transaction-spending-limit-access-group-member.component.html
@@ -2,7 +2,11 @@
   <div class="d-flex justify-content-between align-items-center">
     <div class="d-flex justify-content-start align-items-center py-10px col-12">
       {{ getOperationString() }}{{ !isScoped() ? ' any of' : '' }}
-      {{ (appUser?.ProfileEntryResponse?.Username || accessGroupMemberLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername)}}'s
+      {{
+        appUser?.ProfileEntryResponse?.Username || accessGroupMemberLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check ?
+        (appUser?.ProfileEntryResponse?.Username || accessGroupMemberLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername) + "'s"
+        : 'your'
+      }}
       access group{{ isScoped() ? ' "' + accessGroupMemberLimitMapItem?.AccessGroupKeyName + '"' : 's' }}
       ({{ globalVars.formatTxCountLimit(accessGroupMemberLimitMapItem?.OpCount) }} times).
     </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit-access-group/transaction-spending-limit-access-group.component.html
+++ b/src/app/transaction-spending-limit/transaction-spending-limit-access-group/transaction-spending-limit-access-group.component.html
@@ -2,7 +2,11 @@
   <div class="d-flex justify-content-between align-items-center">
     <div class="d-flex justify-content-start align-items-center py-10px col-12">
       {{ getOperationString() }}{{ !isScoped() ? ' any of' : '' }}
-      {{ (appUser?.ProfileEntryResponse?.Username || accessGroupLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername)}}'s
+      {{
+        appUser?.ProfileEntryResponse?.Username || accessGroupLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check ?
+        (appUser?.ProfileEntryResponse?.Username || accessGroupLimitMapItem?.AccessGroupOwnerPublicKeyBase58Check | truncateAddressOrUsername) + "'s"
+        : 'your'
+      }}
       access group{{ isScoped() ? ' "' + accessGroupLimitMapItem?.AccessGroupKeyName + '"' : 's' }}
       ({{ globalVars.formatTxCountLimit(accessGroupLimitMapItem?.OpCount) }} times).
     </div>

--- a/src/app/transaction-spending-limit/transaction-spending-limit.component.ts
+++ b/src/app/transaction-spending-limit/transaction-spending-limit.component.ts
@@ -127,7 +127,6 @@ export class TransactionSpendingLimitComponent implements OnInit {
     if (!accessGroupLimitMap) {
       return [];
     }
-
     let allPublicKeys = new Set<string>();
     accessGroupLimitMap.forEach((item) => allPublicKeys.add(item.AccessGroupOwnerPublicKeyBase58Check));
     return Array.from(allPublicKeys);


### PR DESCRIPTION
We don't always know the public key that will be selected on the derive page and in order to support access group spending limits with this flow, we can pass an empty string that will be replaced with the selected public key.