### PR TITLE
fix: fix broken avatar directive

### DIFF
--- a/src/app/avatar/avatar.directive.ts
+++ b/src/app/avatar/avatar.directive.ts
@@ -3,6 +3,9 @@ import _ from 'lodash';
 import { BackendAPIService } from '../backend-api.service';
 import { GlobalVarsService } from '../global-vars.service';
 
+const DEFAULT_PROFILE_PIC_URL =
+  window.location.origin + '/assets/placeholder-account-image.png';
+
 @Directive({
   selector: '[appAvatar]',
 })
@@ -21,20 +24,17 @@ export class AvatarDirective implements OnChanges {
     }
 
     if (!this.appAvatar) {
-      this.setURLOnElement(
-        this.backendApi.GetDefaultProfilePictureURL(window.location.host)
-      );
+      this.setURLOnElement(DEFAULT_PROFILE_PIC_URL);
       return;
     }
-    // The fallback route is the route to the pic we use if we can't find an avatar for the user.
-    const fallbackRoute = `fallback=${this.backendApi.GetDefaultProfilePictureURL(
-      window.location.host
-    )}`;
 
     // Although it would be hard for an attacker to inject a malformed public key into the app,
     // we do a basic _.escape anyways just to be extra safe.
     const profPicURL = _.escape(
-      this.backendApi.GetSingleProfilePictureURL(this.appAvatar, fallbackRoute)
+      this.backendApi.GetSingleProfilePictureURL(
+        this.appAvatar,
+        DEFAULT_PROFILE_PIC_URL
+      )
     );
 
     // Set the URL on the element.

--- a/src/app/backend-api.service.ts
+++ b/src/app/backend-api.service.ts
@@ -385,10 +385,6 @@ export class BackendAPIService {
     )}/${PublicKeyBase58Check}?fallback=${FallbackURL}`;
   }
 
-  GetDefaultProfilePictureURL(defaultImgHost: string): string {
-    return defaultImgHost + '/assets/img/default_profile_pic.png';
-  }
-
   JumioBegin(
     PublicKey: string,
     ReferralHashBase58: string,


### PR DESCRIPTION
After a recent styling refactor the avatar directive was broken because
the file it was referencing for the default profile image was removed.

Here we simplify things and just make the avatar directive fully self contained,
as there is no real reason to pass `window.host` or `window.origin` as an argument since
it is a simple globally accessible value.
