### PR TITLE
fix: consider users that have already been issued a derived key

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -66,6 +66,13 @@ export class AppComponent implements OnInit {
       this.globalVars.getFreeDeso = true;
     }
 
+    const authenticatedUsers = new Set(
+      params.get('authenticatedUsers')?.split(',') ?? []
+    );
+    if (authenticatedUsers.size > 0) {
+      this.globalVars.authenticatedUsers = authenticatedUsers;
+    }
+
     if (params.get('subAccounts') === 'true') {
       this.globalVars.subAccounts = true;
     }

--- a/src/app/derive/derive.component.ts
+++ b/src/app/derive/derive.component.ts
@@ -188,6 +188,19 @@ export class DeriveComponent implements OnInit {
           });
           return;
         }
+
+        // If this user has already approved a derived key for login, then we can just log them in
+        // without approval.
+        if (this.globalVars.authenticatedUsers.has(publicKey)) {
+          this.identityService.login({
+            users: this.accountService.getEncryptedUsers(),
+            publicKeyAdded: publicKey,
+          });
+
+          return;
+        }
+
+        // Otherwise, setting the public key will trigger the approval UI to show.
         this.publicKeyBase58Check = publicKey;
       });
   }

--- a/src/app/global-vars.service.ts
+++ b/src/app/global-vars.service.ts
@@ -68,6 +68,15 @@ export class GlobalVarsService {
    */
   subAccounts: boolean = false;
 
+  /**
+   * Set of public keys that have been authenticated by the calling application.
+   * This is used as a hint to decide whether to show the derived key approval
+   * UI or not after the user selects an account to login with. If the account
+   * they select is provided in this set, then we skip the approval UI and issue
+   * a plain login payload.
+   */
+  authenticatedUsers: Set<string> = new Set();
+
   isFullAccessHostname(): boolean {
     return GlobalVarsService.fullAccessHostnames.includes(this.hostname);
   }


### PR DESCRIPTION
Adds ability for an app developer to provide identity a hint
as to which accounts have already been issued derived keys
when they logged into the app. If provided and a user attempts
go through the derived key login flow again, and they select
an account from this list of keys, we skip the derived key approval UI.
