### PR TITLE
sign-up.component.html removed duplicate words "under the under the"

### DIFF
--- a/src/app/sign-up/sign-up.component.html
+++ b/src/app/sign-up/sign-up.component.html
@@ -130,7 +130,7 @@
                 href="https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki"
                 >BIP39</a
               >
-              under the under the m/44'/0'/0'/0/n derivation path.
+              under the m/44'/0'/0'/0/n derivation path.
             </p>
             <p class="padding-top--medium">
               Because of this, you can verify that the wallet is behaving as it


### PR DESCRIPTION
Change from:
Every DeSo wallet consists of a public/private keypair generated using the same key derivation standard used by Bitcoin, namely BIP39 under the under the m/44'/0'/0'/0/n derivation path.

To:
Every DeSo wallet consists of a public/private keypair generated using the same key derivation standard used by Bitcoin, namely BIP39 under the m/44'/0'/0'/0/n derivation path.